### PR TITLE
squid:S1197 - Array designators should be on the type, not the

### DIFF
--- a/src/main/java/org/marlin/geom/Path2D.java
+++ b/src/main/java/org/marlin/geom/Path2D.java
@@ -193,7 +193,7 @@ public abstract class Path2D implements Shape, Cloneable {
      * @since 1.6
      */
     public static class Float extends Path2D implements Serializable {
-        transient float floatCoords[];
+        transient float[] floatCoords;
 
         /**
          * Constructs a new empty single precision {@code Path2D} object
@@ -285,7 +285,7 @@ public abstract class Path2D implements Shape, Cloneable {
         @Override
         float[] cloneCoordsFloat(AffineTransform at) {
             // trim arrays:
-            float ret[];
+            float[] ret;
             if (at == null) {
                 ret = Arrays.copyOf(floatCoords, numCoords);
             } else {
@@ -298,7 +298,7 @@ public abstract class Path2D implements Shape, Cloneable {
         @Override
         double[] cloneCoordsDouble(AffineTransform at) {
             // trim arrays:
-            double ret[] = new double[numCoords];
+            double[] ret = new double[numCoords];
             if (at == null) {
                 for (int i = 0; i < numCoords; i++) {
                     ret[i] = floatCoords[i];
@@ -550,7 +550,7 @@ public abstract class Path2D implements Shape, Cloneable {
                 return 0;
             }
             double movx, movy, curx, cury, endx, endy;
-            float coords[] = floatCoords;
+            float[] coords = floatCoords;
             curx = movx = coords[0];
             cury = movy = coords[1];
             int crossings = 0;
@@ -629,7 +629,7 @@ public abstract class Path2D implements Shape, Cloneable {
             if (numTypes == 0) {
                 return 0;
             }
-            float coords[] = floatCoords;
+            float[] coords = floatCoords;
             double curx, cury, movx, movy, endx, endy;
             curx = movx = coords[0];
             cury = movy = coords[1];
@@ -731,7 +731,7 @@ public abstract class Path2D implements Shape, Cloneable {
          * @since 1.6
          */
         public final void append(PathIterator pi, boolean connect) {
-            float coords[] = new float[6];
+            float[] coords = new float[6];
             while (!pi.isDone()) {
                 switch (pi.currentSegment(coords)) {
                 case SEG_MOVETO:
@@ -996,7 +996,7 @@ public abstract class Path2D implements Shape, Cloneable {
         }
 
         static class CopyIterator extends Path2D.Iterator {
-            float floatCoords[];
+            float[] floatCoords;
 
             CopyIterator(Path2D.Float p2df) {
                 super(p2df);
@@ -1026,7 +1026,7 @@ public abstract class Path2D implements Shape, Cloneable {
         }
 
         static class TxIterator extends Path2D.Iterator {
-            float floatCoords[];
+            float[] floatCoords;
             AffineTransform affine;
 
             TxIterator(Path2D.Float p2df, AffineTransform at) {
@@ -1065,7 +1065,7 @@ public abstract class Path2D implements Shape, Cloneable {
      * @since 1.6
      */
     public static class Double extends Path2D implements Serializable {
-        transient double doubleCoords[];
+        transient double[] doubleCoords;
 
         /**
          * Constructs a new empty double precision {@code Path2D} object
@@ -1157,7 +1157,7 @@ public abstract class Path2D implements Shape, Cloneable {
         @Override
         float[] cloneCoordsFloat(AffineTransform at) {
             // trim arrays:
-            float ret[] = new float[numCoords];
+            float[] ret = new float[numCoords];
             if (at == null) {
                 for (int i = 0; i < numCoords; i++) {
                     ret[i] = (float) doubleCoords[i];
@@ -1171,7 +1171,7 @@ public abstract class Path2D implements Shape, Cloneable {
         @Override
         double[] cloneCoordsDouble(AffineTransform at) {
             // trim arrays:
-            double ret[];
+            double[] ret;
             if (at == null) {
                 ret = Arrays.copyOf(doubleCoords, numCoords);
             } else {
@@ -1311,7 +1311,7 @@ public abstract class Path2D implements Shape, Cloneable {
                 return 0;
             }
             double movx, movy, curx, cury, endx, endy;
-            double coords[] = doubleCoords;
+            double[] coords = doubleCoords;
             curx = movx = coords[0];
             cury = movy = coords[1];
             int crossings = 0;
@@ -1390,7 +1390,7 @@ public abstract class Path2D implements Shape, Cloneable {
             if (numTypes == 0) {
                 return 0;
             }
-            double coords[] = doubleCoords;
+            double[] coords = doubleCoords;
             double curx, cury, movx, movy, endx, endy;
             curx = movx = coords[0];
             cury = movy = coords[1];
@@ -1493,7 +1493,7 @@ public abstract class Path2D implements Shape, Cloneable {
          * @since 1.6
          */
         public final void append(PathIterator pi, boolean connect) {
-            double coords[] = new double[6];
+            double[] coords = new double[6];
             while (!pi.isDone()) {
                 switch (pi.currentSegment(coords)) {
                 case SEG_MOVETO:
@@ -1755,7 +1755,7 @@ public abstract class Path2D implements Shape, Cloneable {
         }
 
         static class CopyIterator extends Path2D.Iterator {
-            double doubleCoords[];
+            double[] doubleCoords;
 
             CopyIterator(Path2D.Double p2dd) {
                 super(p2dd);
@@ -1785,7 +1785,7 @@ public abstract class Path2D implements Shape, Cloneable {
         }
 
         static class TxIterator extends Path2D.Iterator {
-            double doubleCoords[];
+            double[] doubleCoords;
             AffineTransform affine;
 
             TxIterator(Path2D.Double p2dd, AffineTransform at) {
@@ -2504,8 +2504,8 @@ public abstract class Path2D implements Shape, Cloneable {
     {
         s.defaultWriteObject();
 
-        float fCoords[];
-        double dCoords[];
+        float[] fCoords;
+        double[] dCoords;
 
         if (isdbl) {
             dCoords = ((Path2D.Double) this).doubleCoords;
@@ -2690,7 +2690,7 @@ public abstract class Path2D implements Shape, Cloneable {
         int pointIdx;
         Path2D path;
 
-        static final int curvecoords[] = {2, 2, 4, 6, 0};
+        static final int[] curvecoords = {2, 2, 4, 6, 0};
 
         Iterator(Path2D path) {
             this.path = path;

--- a/src/main/java/org/marlin/pisces/Helpers.java
+++ b/src/main/java/org/marlin/pisces/Helpers.java
@@ -249,9 +249,9 @@ final class Helpers implements MarlinConst {
      * the 6 right coordinates
      * @since 1.7
      */
-    static void subdivideCubic(float src[], int srcoff,
-                               float left[], int leftoff,
-                               float right[], int rightoff)
+    static void subdivideCubic(float[] src, int srcoff,
+                               float[] left, int leftoff,
+                               float[] right, int rightoff)
     {
         float x1 = src[srcoff + 0];
         float y1 = src[srcoff + 1];
@@ -300,9 +300,9 @@ final class Helpers implements MarlinConst {
     }
 
 
-    static void subdivideCubicAt(float t, float src[], int srcoff,
-                                 float left[], int leftoff,
-                                 float right[], int rightoff)
+    static void subdivideCubicAt(float t, float[] src, int srcoff,
+                                 float[] left, int leftoff,
+                                 float[] right, int rightoff)
     {
         float x1 = src[srcoff + 0];
         float y1 = src[srcoff + 1];
@@ -350,9 +350,9 @@ final class Helpers implements MarlinConst {
         }
     }
 
-    static void subdivideQuad(float src[], int srcoff,
-                              float left[], int leftoff,
-                              float right[], int rightoff)
+    static void subdivideQuad(float[] src, int srcoff,
+                              float[] left, int leftoff,
+                              float[] right, int rightoff)
     {
         float x1 = src[srcoff + 0];
         float y1 = src[srcoff + 1];
@@ -388,9 +388,9 @@ final class Helpers implements MarlinConst {
         }
     }
 
-    static void subdivideQuadAt(float t, float src[], int srcoff,
-                                float left[], int leftoff,
-                                float right[], int rightoff)
+    static void subdivideQuadAt(float t, float[] src, int srcoff,
+                                float[] left, int leftoff,
+                                float[] right, int rightoff)
     {
         float x1 = src[srcoff + 0];
         float y1 = src[srcoff + 1];
@@ -426,9 +426,9 @@ final class Helpers implements MarlinConst {
         }
     }
 
-    static void subdivideAt(float t, float src[], int srcoff,
-                            float left[], int leftoff,
-                            float right[], int rightoff, int size)
+    static void subdivideAt(float t, float[] src, int srcoff,
+                            float[] left, int leftoff,
+                            float[] right, int rightoff, int size)
     {
         switch(size) {
         case 8:

--- a/src/main/java/org/marlin/pisces/MarlinRenderingEngine.java
+++ b/src/main/java/org/marlin/pisces/MarlinRenderingEngine.java
@@ -80,7 +80,7 @@ public class MarlinRenderingEngine extends RenderingEngine
                                     int caps,
                                     int join,
                                     float miterlimit,
-                                    float dashes[],
+                                    float[] dashes,
                                     float dashphase)
     {
         final RendererContext rdrCtx = getRendererContext();
@@ -273,7 +273,7 @@ public class MarlinRenderingEngine extends RenderingEngine
                         int caps,
                         int join,
                         float miterlimit,
-                        float dashes[],
+                        float[] dashes,
                         float dashphase,
                         PathConsumer2D pc2d)
     {
@@ -713,7 +713,7 @@ public class MarlinRenderingEngine extends RenderingEngine
                                               BasicStroke bs,
                                               boolean thin,
                                               boolean normalize,
-                                              int bbox[])
+                                              int[] bbox)
     {
         MarlinTileGenerator ptg = null;
         Renderer r = null;
@@ -771,7 +771,7 @@ public class MarlinRenderingEngine extends RenderingEngine
                                                     double dx2, double dy2,
                                                     double lw1, double lw2,
                                                     Region clip,
-                                                    int bbox[])
+                                                    int[] bbox)
     {
         // REMIND: Deal with large coordinates!
         double ldx1, ldy1, ldx2, ldy2;

--- a/src/main/java/org/marlin/pisces/MarlinTileGenerator.java
+++ b/src/main/java/org/marlin/pisces/MarlinTileGenerator.java
@@ -65,7 +65,7 @@ final class MarlinTileGenerator implements AATileGenerator, MarlinConst {
         MarlinRenderingEngine.returnRendererContext(rdr.rdrCtx);
     }
 
-    void getBbox(int bbox[]) {
+    void getBbox(int[] bbox) {
         bbox[0] = cache.bboxX0;
         bbox[1] = cache.bboxY0;
         bbox[2] = cache.bboxX1;
@@ -155,8 +155,8 @@ final class MarlinTileGenerator implements AATileGenerator, MarlinConst {
      * once per tile, but not both.
      */
     @Override
-    public void getAlpha(final byte tile[], final int offset,
-                                            final int rowstride)
+    public void getAlpha(final byte[] tile, final int offset,
+                         final int rowstride)
     {
         if (DO_MONITORS) {
             RendererContext.stats.mon_ptg_getAlpha.start();

--- a/src/main/java/sun/java2d/pipe/AAShapePipe.java
+++ b/src/main/java/sun/java2d/pipe/AAShapePipe.java
@@ -143,7 +143,7 @@ public class AAShapePipe
     }
 
     public void renderTiles(SunGraphics2D sg, Shape s,
-                            AATileGenerator aatg, int abox[], TileState ts)
+                            AATileGenerator aatg, int[] abox, TileState ts)
     {
         Object context = null;
         try {

--- a/src/main/java/test/QuickSort.java
+++ b/src/main/java/test/QuickSort.java
@@ -32,7 +32,7 @@ final class QuickSort {
     /**
      * Sorts the specified sub-array of integers into ascending order.
      */
-    static void sort1(final int x[], final int y[], final int off, final int len) {
+    static void sort1(final int[] x, final int[] y, final int off, final int len) {
         int t;
         // Insertion sort on smallest arrays
         if (len < 20) { // 7 in jdk8 or 20 as benchmark ?
@@ -150,7 +150,7 @@ final class QuickSort {
     /**
      * Returns the index of the median of the three indexed integers.
      */
-    private static int med3(final int x[], final int a, final int b, final int c) {
+    private static int med3(final int[] x, final int a, final int b, final int c) {
         return (x[a] < x[b]
                 ? (x[b] < x[c] ? b : x[a] < x[c] ? c : a)
                 : (x[b] > x[c] ? b : x[a] > x[c] ? c : a));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - Array designators "[]" should be on the type, not the variable

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197

Please let me know if you have any questions.

M-Ezzat